### PR TITLE
Add essay: Batman or Spiderman

### DIFF
--- a/_posts/2026-03-25-batman-or-spiderman.md
+++ b/_posts/2026-03-25-batman-or-spiderman.md
@@ -1,0 +1,58 @@
+---
+layout: post
+title: "Batman or Spiderman"
+categories: Philosophy
+author: Samagra Sharma
+---
+
+Someone asked me this at a house party in San Francisco, the kind where the music is too loud and everyone is either a founder or pretending to be one. The room picked Batman. The room always picks Batman. The brooding genius, the billionaire who chose discipline over grief, the man who made himself invulnerable through sheer will. People love him because he represents a fantasy that feels achievable: suffer enough, train hard enough, refuse enough softness, and you too can transcend the human condition.
+
+I said Spiderman, and the conversation moved on the way conversations do when you've given the less interesting answer. For a long time I thought it was a lesser choice, the way you might think preferring chai over single malt is somehow less sophisticated. It took me years to realize I was picking the harder philosophy and calling it the easier hero.
+
+## Two theories of duty
+
+There are two ways to think about what you owe the world.
+
+The first says: detach. Let go of outcomes, let go of relationships, let go of the personal and become pure instrument. This is the Stoic path, the ascetic path, and in its most refined form, a certain reading of the Gita where कर्मण्येवाधिकारस्ते becomes a mandate to act without feeling. Batman lives here. His parents die in an alley and he transmutes that grief into a system. Every relationship he forms afterwards is structured around his mission: Alfred serves it, the Robins are recruited into it, Commissioner Gordon is a tool of it. Love exists, but only as fuel, never as a force that might redirect him.
+
+The second way says: your duty arises from your relationships, your station, your particular entanglements with the people around you. This is dharma in its classical sense, where what you owe depends on who you are to whom. Spiderman lives here. His heroism is born from a specific guilt, Uncle Ben dying in an alley because Peter chose not to act, and sustained by specific loves, Aunt May worrying about his safety and MJ furious that he's always late, and tested by specific failures that actually change him. He keeps getting pulled away from the hero work by the human work, and that tension is where the real story lives.
+
+I think people pick Batman because detachment dressed as discipline looks like strength from the outside, and staying in the mess of your relationships while trying to save the world looks like weakness.
+
+## The Batcave inside yourself
+
+Batman's appeal contains a specific promise: that if you suffer enough and control enough and refuse enough vulnerability, you become untouchable. His trauma becomes his superpower and his isolation becomes his clarity. Every contingency is planned, every variable accounted for, every weakness transformed into a weapon.
+
+This is deeply appealing, especially if you've been hurt. The promise is that you can build a Batcave inside yourself where nothing reaches you, and from that fortress of solitude you can save the world on your own terms. Founders love this story. So do high-achievers, competitive exam toppers, anyone who learned early that self-reliance is the highest virtue and needing people is a structural weakness.
+
+It works just well enough to be dangerous. You can actually build a life on Batman's philosophy. You can isolate, optimize, control, and produce extraordinary results for a surprisingly long time. What becomes harder to do, over enough years, is sustain it, because the human parts you amputated to become the machine eventually demand their due.
+
+## Choosing connection again
+
+Spiderman never gets the option of invulnerability. He keeps failing and losing people, and he makes choices that haunt him, and he sits with the consequences in a way Batman never has to, because Batman's wealth and infrastructure absorb the cost of his decisions while Spiderman absorbs them in his body, his relationships, his rent.
+
+And every single time, after every failure, he has to choose connection again. Go back to Aunt May's apartment knowing she'll worry. Call MJ knowing she's furious. Swing back out into the city knowing he'll probably get hurt again, and that this time there's no Batcave to retreat to, only a cramped Queens apartment and a biology textbook he's three chapters behind on.
+
+Choosing vulnerability repeatedly, with full knowledge of its cost, might be the more difficult philosophical position. I keep finding evidence for this in places I wouldn't expect: the greatest figures in devotional literature are rarely the renunciates who left the world but the ones who stayed in it and let it reshape them. Mirabai stayed in her body. The Gopis lived inside their longing for Krishna, and the living was the practice.
+
+## Precision and resonance
+
+I keep seeing this play out in how people build companies.
+
+You can build infrastructure. Clean, elegant, technically brilliant systems that solve hard problems. This is Batman energy: controlled, capital-efficient, indispensable. The work is pure because it answers to engineering constraints, and engineering constraints are honest in a way human needs rarely are.
+
+Or you can build something that requires you to stay embedded in the mess of what people actually want, actually share, actually care about. Consumer products, creative tools, social platforms. This work is closer to Spiderman: you are constantly being pulled by forces you cannot fully control, constantly failing in public, constantly discovering that the thing you built is different from what people needed, and adjusting from a position of listening rather than mastery.
+
+The infrastructure path is seductive because it feels like competence and the consumer path is terrifying because it feels like exposure. One scales through precision and the other through resonance, and resonance requires staying human enough to feel what others feel, which means the Batcave, however tempting, is exactly the thing you have to give up.
+
+I've tried both. I'm still learning which one I'm actually built for, but I know where the energy comes from, and it comes from the mess, from the people, from staying close enough to hear what someone wants to create before they fully know how to say it.
+
+## Hanuman's refusal
+
+There is a figure in Hindu tradition who I think about more than any Western superhero when I'm trying to work this out. Hanuman is stronger than Ram and Ravana both, powerful enough to carry a mountain across the sky, and he chooses to serve. He fights his own son Makaradhwaja and feels pride when his son fights well, because the boy is following his dharma. He forgets his own strength until Jambavan reminds him, which means his power lives in relationship, not in isolation. He could justify solitude more than anyone and he refuses it every single time.
+
+That is the version of strength I keep returning to, though I'm still learning how to practice it. I'm twenty-seven, building a company while caring for family while learning how to love someone while writing about dharma for people my age, and most days the tension between the Batman impulse and the Spiderman instinct is a live wire. The temptation to retreat into pure competence, to build the Batcave and lock the door, shows up more often than I'd like to admit.
+
+But every time I've followed that impulse, something essential went quiet. And every time I've stayed in the relationships, let people change me even when it was uncomfortable, the work got better and the life got richer in ways I couldn't have planned for.
+
+I pick Spiderman, and I think I always will, and I'm still figuring out everything that means.


### PR DESCRIPTION
## Summary
- Adds new Philosophy essay "Batman or Spiderman" exploring two theories of duty through the lens of superhero archetypes
- Draws on Stoic philosophy, the Bhagavad Gita, and Hanuman to contrast detachment vs relational dharma
- Filed under the Philosophy category, consistent with existing essays

## Test plan
- [ ] Verify the post renders correctly on the Jekyll site
- [ ] Confirm frontmatter (title, category, author) displays properly
- [ ] Check that Hindi/Sanskrit text (कर्मण्येवाधिकारस्ते) renders correctly

https://claude.ai/code/session_01MnZ1u7uvcNtpVgmshg2sQm