### PR TITLE
Publish Dharma Artha Kaam Moksha as unlisted preview

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,6 +16,8 @@ layout: base
     {% assign posts = site.posts %}
   {% endif %}
 
+  {% assign posts = posts | where_exp: "post", "post.unlisted != true" %}
+
 
   {%- if posts.size > 0 -%}
     {%- if page.list_title -%}

--- a/_posts/2026-04-06-dharma-artha-kaam-moksha.md
+++ b/_posts/2026-04-06-dharma-artha-kaam-moksha.md
@@ -4,6 +4,9 @@ title: "Dharma Artha Kaam Moksha: The Colonial Lobotomy"
 categories: Philosophy
 author: Samagra Sharma
 date: 2026-04-06
+unlisted: true
+sitemap: false
+permalink: /preview/dharma-artha-kaam-moksha-dhk9x2m7/
 ---
 
 The room smelled of camphor and sandalwood and sweat. A young man lay on a cotton mattress in a ganika's salon in Pataliputra. She traced the line of his jaw with her fingers and asked him what he thought of Panini's rule on compound nouns. She was testing him. Her training covered the sixty-four arts, and conversation after sex was one of them. A man who only held a woman's body had learned half of what she was teaching. Downstairs, her attendant tuned a veena. In the next room, a minister's son was reciting a verse he had composed for her, badly. The state funded this establishment with 1,000 silver panas, roughly a million dollars today, and the university where the young man studied logic. It saw no difference between the two investments.


### PR DESCRIPTION
## Summary
Follow-up to #34, which merged only the initial `_drafts/` commit. This PR adds the actual preview-link infrastructure so the draft is shareable for review.

- Moves `2026-04-06-dharma-artha-kaam-moksha.md` from `_drafts/` to `_posts/`
- Adds `unlisted: true`, `sitemap: false`, and a custom obscure permalink
- Patches `_layouts/home.html` to filter `unlisted: true` posts from the blog/home listing

## Preview URL (live after merge)
https://samagra.me/preview/dharma-artha-kaam-moksha-dhk9x2m7/

## How it stays hidden
- `unlisted: true` + home-layout filter → absent from `/blog/` and homepage
- `sitemap: false` → excluded from `sitemap.xml`
- Random-suffix permalink → not discoverable by guessing

## Caveat
`feed.xml` (jekyll-feed) still includes it — no per-post exclusion in that plugin. When ready to publish properly, drop `unlisted`, `sitemap: false`, and the custom `permalink` so it lands at the normal `/philosophy/2026/04/06/...` URL.

## Test plan
- [ ] Merge and confirm `/preview/dharma-artha-kaam-moksha-dhk9x2m7/` loads on samagra.me
- [ ] Confirm the post is absent from `/blog/` and the homepage
- [ ] Confirm it's absent from `/sitemap.xml`

https://claude.ai/code/session_01DYEfgCUK3RsuWeNYdPyj3V